### PR TITLE
docs: enforce documentation and design explanations in PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,10 +21,17 @@
    npm run build
    ```
 
+## Documentation
+
+- Update documentation for any feature changes.
+- Record design decisions in `/docs` or an ADR log.
+
 ## Pull requests
 
 - Ensure `dist/` contains the latest build.
 - Follow the coding guidelines in `AGENTS.md`.
+- Include relevant documentation changes.
+- Explain significant architectural decisions in the pull request description.
 - The `main` branch is protected:
   - direct pushes are blocked,
   - open pull requests from `dev` and wait for at least one approving review, and


### PR DESCRIPTION
## Summary
- require docs and design notes for feature changes
- ensure PRs include doc updates and highlight architecture decisions

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b54450c120832d8f544d628cd44fe9