### PR TITLE
docs: add versioning strategy

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,0 +1,25 @@
+# Versioning Strategy
+
+This project follows [Semantic Versioning](https://semver.org/) for all releases.
+
+## Version Format
+
+```
+MAJOR.MINOR.PATCH
+```
+
+- **MAJOR** – incompatible API changes.
+- **MINOR** – backwards-compatible functionality additions.
+- **PATCH** – backwards-compatible bug fixes.
+
+## Release Process
+
+1. Start from the `dev` branch.
+2. Update the `version` field in `package.json`.
+3. Run `npm run format`, `npm run lint`, and `npm run build` to ensure code quality and update `dist/`.
+4. Commit the changes and create a Git tag matching the version, e.g. `v1.2.3`.
+5. Merge `dev` into `main` and push the tag.
+
+## Initial Version
+
+The tag `v0.1.0` marks the initial baseline for the project and can be used as a fallback if needed.


### PR DESCRIPTION
## Summary
- document semantic versioning workflow and initial tag

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b54ca2cde0832d893a70dc5e51bf54