### PR TITLE
docs: update branching workflow to single main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,8 +2,9 @@
 
 ## Branch strategy
 
-- `main` contains production-ready code.
-- `dev` is the integration branch for feature work. Create feature branches from `dev` and open pull requests back to `dev`. Releases merge from `dev` into `main`.
+- `main` is the only long-lived branch and contains production-ready code.
+- Create temporary feature branches from `main` and open pull requests back to `main` when work is ready.
+- Frequent tagged releases from `main` provide stable fallback points if a feature branch introduces issues.
 
 ## Development
 
@@ -34,5 +35,5 @@
 - Explain significant architectural decisions in the pull request description.
 - The `main` branch is protected:
   - direct pushes are blocked,
-  - open pull requests from `dev` and wait for at least one approving review, and
+  - open pull requests from feature branches and wait for at least one approving review, and
   - CI must report success via the `build` workflow (runs lint and build) before merging.

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -14,11 +14,13 @@ MAJOR.MINOR.PATCH
 
 ## Release Process
 
-1. Start from the `dev` branch.
+1. Start from the `main` branch.
 2. Update the `version` field in `package.json`.
 3. Run `npm run format`, `npm run lint`, and `npm run build` to ensure code quality and update `dist/`.
 4. Commit the changes and create a Git tag matching the version, e.g. `v1.2.3`.
-5. Merge `dev` into `main` and push the tag.
+5. Push `main` and the tag to the remote.
+
+Each tag represents a stable release, allowing easy rollback if a feature branch introduces breaking changes.
 
 ## Initial Version
 


### PR DESCRIPTION
## Summary
- document main as the only long-lived branch
- clarify feature branch PR workflow and frequent tagged releases
- update versioning instructions to release directly from main

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5607d4570832dbda1de859e8bcc70