### PR TITLE
Scaffold core modules for family grid calendar

### DIFF
--- a/dist/family-grid-calendar.js
+++ b/dist/family-grid-calendar.js
@@ -24,7 +24,7 @@ var Mt=Object.create;var I=Object.defineProperty;var Rt=Object.getOwnPropertyDes
  * @license
  * Copyright 2021 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
- */var X;((X=window.HTMLSlotElement)===null||X===void 0?void 0:X.prototype.assignedElements)!=null;var Ct,Y,ie;Ct=[se("family-grid-calendar-card")];class R extends(ie=H){render(){return Jt`<div>Family Grid Calendar Card</div>`}}Y=at(ie),R=ut(Y,0,"FamilyGridCalendarCard",Ct,R),pt(R,"styles",zt`
+ */var X;((X=window.HTMLSlotElement)===null||X===void 0?void 0:X.prototype.assignedElements)!=null;var Ct,Y,ie;Ct=[se("family-grid-calendar")];class R extends(ie=H){render(){return Jt`<div>Family Grid Calendar</div>`}}Y=at(ie),R=ut(Y,0,"FamilyGridCalendar",Ct,R),pt(R,"styles",zt`
     :host {
       display: block;
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,15 @@
+export interface CalendarConfig {
+  entity: string;
+  name?: string;
+  color?: string;
+  weather_entity?: string;
+}
+
+export interface FamilyGridCalendarConfig {
+  type: 'custom:family-grid-calendar';
+  calendars: CalendarConfig[];
+  weather_entity?: string;
+  data_refresh_minutes?: number;
+}
+
+export const DEFAULT_REFRESH_MINUTES = 15;

--- a/src/family-grid-calendar.ts
+++ b/src/family-grid-calendar.ts
@@ -1,8 +1,8 @@
 import { LitElement, html, css } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
-@customElement('family-grid-calendar-card')
-export class FamilyGridCalendarCard extends LitElement {
+@customElement('family-grid-calendar')
+export class FamilyGridCalendar extends LitElement {
   static styles = css`
     :host {
       display: block;
@@ -10,12 +10,12 @@ export class FamilyGridCalendarCard extends LitElement {
   `;
 
   render() {
-    return html`<div>Family Grid Calendar Card</div>`;
+    return html`<div>Family Grid Calendar</div>`;
   }
 }
 
 declare global {
   interface HTMLElementTagNameMap {
-    'family-grid-calendar-card': FamilyGridCalendarCard;
+    'family-grid-calendar': FamilyGridCalendar;
   }
 }

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,4 @@
+import type { HomeAssistant } from './locale';
+
+export const tr = (hass: HomeAssistant | undefined, key: string): string =>
+  hass?.localize?.(key) ?? key;

--- a/src/locale.ts
+++ b/src/locale.ts
@@ -1,0 +1,19 @@
+export interface HomeAssistant {
+  localize?: (key: string, ...args: unknown[]) => string;
+  callWS?: <T>(msg: unknown) => Promise<T>;
+  locale: {
+    language: string;
+    time_format?: string;
+  };
+}
+
+export const formatWeekday = (hass: HomeAssistant, date: Date): string =>
+  new Intl.DateTimeFormat(hass.locale.language, { weekday: 'short' }).format(date);
+
+export const formatDate = (hass: HomeAssistant, date: Date): string =>
+  new Intl.DateTimeFormat(hass.locale.language, { day: 'numeric', month: 'short' }).format(date);
+
+export const formatTime = (hass: HomeAssistant, date: Date): string =>
+  new Intl.DateTimeFormat(hass.locale.language, { hour: '2-digit', minute: '2-digit' }).format(
+    date,
+  );

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,9 @@
+export const HOURS = Array.from({ length: 24 }, (_, i) => `${i.toString().padStart(2, '0')}:00`);
+
+export function getDayKey(date: Date): string {
+  return date.toISOString().split('T')[0];
+}
+
+export function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}

--- a/src/weather.ts
+++ b/src/weather.ts
@@ -1,0 +1,42 @@
+import type { HomeAssistant } from './locale';
+
+export interface DailyForecast {
+  date: string;
+  high?: number;
+  low?: number;
+  condition?: string;
+  precipitation_probability?: number;
+}
+
+export async function fetchDailyForecast(
+  hass: HomeAssistant,
+  entity: string,
+): Promise<DailyForecast[]> {
+  try {
+    const result = await hass.callWS?.({
+      type: 'weather/get_forecast',
+      entity_id: entity,
+      forecast_type: 'daily',
+    });
+    if (
+      result &&
+      typeof result === 'object' &&
+      'forecast' in result &&
+      Array.isArray((result as { forecast: unknown }).forecast)
+    ) {
+      return (result as { forecast: Record<string, unknown>[] }).forecast.map((day) => ({
+        date: String(day.datetime),
+        high: typeof day.temperature === 'number' ? day.temperature : undefined,
+        low: typeof day.templow === 'number' ? day.templow : undefined,
+        condition: typeof day.condition === 'string' ? day.condition : undefined,
+        precipitation_probability:
+          typeof day.precipitation_probability === 'number'
+            ? day.precipitation_probability
+            : undefined,
+      }));
+    }
+  } catch (err) {
+    // ignore errors and fall through to empty array
+  }
+  return [];
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     outDir: 'dist',
     emptyOutDir: true,
     rollupOptions: {
-      input: resolve(__dirname, 'src/family-grid-calendar-card.ts'),
+      input: resolve(__dirname, 'src/family-grid-calendar.ts'),
       output: {
         entryFileNames: 'family-grid-calendar.js',
         format: 'es',


### PR DESCRIPTION
## Summary
- rename card component to `family-grid-calendar`
- add scaffolding modules for config, utils, locale, i18n, and weather
- adjust Vite entry and commit build output

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b56e6c5630832d9f573953df426d56